### PR TITLE
Update workflow to run in container with device access

### DIFF
--- a/.github/workflows/teensy-upload.yml
+++ b/.github/workflows/teensy-upload.yml
@@ -20,21 +20,15 @@ on:
 jobs:
   upload:
     runs-on: self-hosted
+    container:
+      image: platformio/platformio-core:latest
+      options: --device /dev/serial/by-id/usb-Teensyduino_USB_Serial_11419230-if00
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-      
-      - name: Install PlatformIO
-        run: pip install platformio
       
       - name: Upload to Teensy
         run: pio run -t upload
       
       - name: Monitor Serial Output
         run: |
-          stty -F /dev/serial/by-id/usb-Teensyduino_USB_Serial_11419230-if00 ${{ github.event.inputs.baud_rate }}
           timeout ${{ github.event.inputs.timeout }}s cat /dev/serial/by-id/usb-Teensyduino_USB_Serial_11419230-if00


### PR DESCRIPTION
This PR updates the workflow to run in a container with device access, removing the `stty` command and ensuring the serial device is accessible.